### PR TITLE
Default manager export

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@slynova/flydrive"><img src="https://img.shields.io/npm/dm/@slynova/flydrive.svg?style=flat-square" alt="Download"></a>
-  <a href="https://www.npmjs.com/package/@slynova/flydrive"><img src="https://img.shields.io/npm/v/@slynova/flydrive.svg?style=flat-square" alt="Version"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/npm/l/@slynova/flydrive.svg?style=flat-square" alt="License"></a>
+  <a href="https://www.npmjs.com/package/@pdspicer/flydrive"><img src="https://img.shields.io/npm/dm/@pdspicer/flydrive.svg?style=flat-square" alt="Download"></a>
+  <a href="https://www.npmjs.com/package/@pdspicer/flydrive"><img src="https://img.shields.io/npm/v/@pdspicer/flydrive.svg?style=flat-square" alt="Version"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/npm/l/@pdspicer/flydrive.svg?style=flat-square" alt="License"></a>
 </p>
 
 `flydrive` is a framework-agnostic package which provides a powerful wrapper to manage file Storage in [Node.js](https://nodejs.org).
@@ -27,16 +27,16 @@ This package is available in the npm registry.
 It can easily be installed with `npm` or `yarn`.
 
 ```bash
-$ npm i @slynova/flydrive
+$ npm i @pdspicer/flydrive
 # or
-$ yarn add @slynova/flydrive
+$ yarn add @pdspicer/flydrive
 ```
 
 When you require the package in your file, it will give you access to the `StorageManager` class.
 This class is a facade for the package and should be instantiated with a [configuration object](https://github.com/Slynova-Org/flydrive/blob/master/test/stubs/config.ts).
 
 ```javascript
-const { StorageManager } = require('@slynova/flydrive');
+const { StorageManager } = require('@pdspicer/flydrive');
 const storage = new StorageManager(config);
 ```
 
@@ -62,7 +62,7 @@ storage.disk('local').getSignedUrl();
 Since we are using TypeScript, you can make use of casting to get the real interface:
 
 ```typescript
-import { LocalFileSystem } from '@slynova/flydrive';
+import { LocalFileSystem } from '@pdspicer/flydrive';
 
 storage.disk<LocalFileSystem>('local');
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@slynova/flydrive",
-  "version": "1.0.0-0",
+  "name": "flydrive-manager",
+  "version": "1.0.5",
   "description": "Flexible and Fluent way to manage storage in Node.js.",
   "main": "./build/index.js",
   "license": "MIT",
@@ -20,7 +20,8 @@
   "contributors": [
     "Harminder Virk <virk@adonisjs.com>",
     "Michaël Zasso <targos@pm.me>",
-    "Krzysztof Chrapka <krzysztof.chrapka gamfi pl>"
+    "Krzysztof Chrapka <krzysztof.chrapka gamfi pl>",
+    "Paul Spicer <pdspicer@gmail.com>"
   ],
   "files": [
     "build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flydrive-manager",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Flexible and Fluent way to manage storage in Node.js.",
   "main": "./build/index.js",
   "license": "MIT",

--- a/src/Storage/AmazonWebServicesS3Storage.ts
+++ b/src/Storage/AmazonWebServicesS3Storage.ts
@@ -6,7 +6,7 @@
  */
 
 import { Readable } from 'stream';
-import S3, { ClientConfiguration } from 'aws-sdk/clients/s3';
+import S3 from 'aws-sdk/clients/s3';
 import {UnknownException, NoSuchBucket, FileNotFound, InvalidInput, PermissionMissing} from '../Exceptions';
 import {
 	ContentResponse,
@@ -22,6 +22,8 @@ import {
 import { MetadataConverter } from '../utils/MetadataConverter'
 import { isReadableStream } from "../utils";
 import { Storage } from "./Storage";
+import {Agent as httpAgent} from "http";
+import {Agent as httpsAgent} from "https";
 
 function handleError(err: Error, path: string, bucket: string): Error {
 	switch (err.name) {
@@ -37,7 +39,7 @@ function handleError(err: Error, path: string, bucket: string): Error {
 }
 
 export class AmazonWebServicesS3Storage extends Storage {
-	constructor(protected readonly $driver: S3, protected readonly $bucket: string) {
+	private constructor(private readonly $driver: S3, protected readonly $bucket: string) {
 		super();
 	}
 
@@ -281,8 +283,75 @@ export class AmazonWebServicesS3Storage extends Storage {
 	}
 }
 
-export interface AWSS3Config extends ClientConfiguration {
+export interface AWSS3Config {
 	key: string;
 	secret: string;
 	bucket: string;
+	endpoint?: string;
+	params?: {
+		[key: string]: any;
+	};
+	computeChecksums?: boolean;
+	convertResponseTypes?: boolean;
+	correctClockSkew?: boolean;
+	customUserAgent?: string;
+	credentials?: AWSCredentials|null;
+	credentialProvider?: AWSCredentialProviderChain;
+	httpOptions?: {
+		proxy?: string;
+		agent?: httpAgent | httpsAgent;
+		connectTimeout?: number;
+		timeout?: number;
+		xhrAsync?: boolean;
+		xhrWithCredentials?: boolean;
+	};
+	logger?: {
+		write?: (...any) => void;
+		log?: (...any) => void;
+	};
+	maxRedirects?: number;
+	maxRetries?: number;
+	paramValidation?: boolean | {
+		min?: boolean;
+		max?: boolean;
+		pattern?: boolean;
+		enum?: boolean;
+	};
+	region?: string;
+	retryDelayOptions?: {
+		base?: number;
+		customBackoff?: (retryCount: number, err?: Error) => number;
+	};
+	s3BucketEndpoint?: boolean;
+	s3DisableBodySigning?: boolean;
+	s3ForcePathStyle?: boolean;
+	s3UsEast1RegionalEndpoint?: "regional"|"legacy";
+	s3UseArnRegion?: boolean;
+	signatureCache?: boolean;
+	signatureVersion?: "v2"|"v3"|"v4"|string;
+	sslEnabled?: boolean;
+	systemClockOffset?: number;
+	useAccelerateEndpoint?: boolean;
+	dynamoDbCrc32?: boolean;
+	endpointDiscoveryEnabled?: boolean;
+	endpointCacheSize?: number;
+	hostPrefixEnabled?: boolean;
+	stsRegionalEndpoints?: "legacy"|"regional";
+	useDualstack?: boolean;
+	apiVersion?: "2006-03-01"|"latest"|string;
 }
+
+export interface AWSCredentials {
+	accessKeyId: string
+	secretAccessKey: string
+	sessionToken?: string
+	expired?: boolean;
+	expireTime?: Date;
+}
+
+export interface AWSCredentialProviderChain {
+	resolve(callback:(err: any, credentials: AWSCredentials) => void): AWSCredentialProviderChain;
+	resolvePromise(): Promise<AWSCredentials>;
+	providers: AWSCredentials[]|(() => AWSCredentials)[];
+}
+

--- a/src/Storage/GoogleCloudStorage.ts
+++ b/src/Storage/GoogleCloudStorage.ts
@@ -6,7 +6,7 @@
  */
 
 import { Readable } from 'stream';
-import {StorageOptions, Bucket, File, CreateWriteStreamOptions} from '@google-cloud/storage';
+import {Bucket, File, CreateWriteStreamOptions} from '@google-cloud/storage';
 import { Storage } from './Storage';
 import { isReadableStream, pipeline } from '../utils';
 import {
@@ -18,9 +18,15 @@ import {
 	PropertiesResponse,
 	FileListResponse, PutOptions, DeleteResponse
 } from '../types';
-import { FileNotFound, PermissionMissing, UnknownException, AuthorizationRequired, WrongKeyPath } from '../Exceptions';
+import {
+	FileNotFound,
+	PermissionMissing,
+	UnknownException,
+	AuthorizationRequired,
+	WrongKeyPath,
+	InvalidInput
+} from '../Exceptions';
 import {MetadataConverter} from "../utils/MetadataConverter";
-import {InvalidInput} from "../Exceptions/InvalidInput";
 
 function handleError(err: Error & { code?: number | string }, path: string): Error {
 	switch (err.code) {
@@ -38,7 +44,7 @@ function handleError(err: Error & { code?: number | string }, path: string): Err
 }
 
 export class GoogleCloudStorage extends Storage {
-	public constructor(private readonly $bucket: Bucket) {
+	private constructor(private readonly $bucket: Bucket) {
 		super();
 	}
 
@@ -260,6 +266,48 @@ export class GoogleCloudStorage extends Storage {
 	}
 }
 
-export interface GoogleCloudStorageConfig extends StorageOptions {
+export interface GoogleCloudStorageConfig {
 	bucket: string;
+	autoRetry?: boolean;
+	maxRetries?: number;
+	promise?: typeof Promise;
+	apiEndpoint?: string;
+	keyFilename?: string;
+	keyFile?: string;
+	credentials?: CredentialBody;
+	clientOptions?: JWTOptions | OAuth2ClientOptions | UserRefreshClientOptions;
+	scopes?: string | string[];
+	projectId?: string;
+}
+
+export interface CredentialBody {
+	client_email?: string;
+	private_key?: string;
+}
+
+export interface JWTOptions extends RefreshOptions {
+	email?: string;
+	keyFile?: string;
+	key?: string;
+	keyId?: string;
+	scopes?: string | string[];
+	subject?: string;
+	additionalClaims?: {};
+}
+
+export interface OAuth2ClientOptions extends RefreshOptions {
+	clientId?: string;
+	clientSecret?: string;
+	redirectUri?: string;
+}
+
+export interface UserRefreshClientOptions extends RefreshOptions {
+	clientId?: string;
+	clientSecret?: string;
+	refreshToken?: string;
+}
+
+export interface RefreshOptions {
+	eagerRefreshThresholdMillis?: number;
+	forceRefreshOnFailure?: boolean;
 }

--- a/src/Storage/LocalStorage.ts
+++ b/src/Storage/LocalStorage.ts
@@ -90,7 +90,7 @@ export class LocalStorage extends Storage {
 	 */
 	public async delete(location: string): Promise<DeleteResponse> {
 		const fullPath = this.dataPath(location);
-		let wasDeleted: boolean = true;
+		let wasDeleted = true;
 
 		try {
 			await Promise.all([
@@ -271,7 +271,7 @@ export class LocalStorage extends Storage {
 	}
 
 	private async *flatListAbsolute(prefix: string): AsyncGenerator<FileListResponse> {
-		let prefixDirectory = (prefix[prefix.length-1] === '/') ? prefix : dirname(prefix);
+		const prefixDirectory = (prefix[prefix.length-1] === '/') ? prefix : dirname(prefix);
 
 		try {
 			for (const file of await promisify(fs.readdir)(prefixDirectory, {withFileTypes: true, encoding: 'utf-8'})) {

--- a/src/Storage/LocalStorage.ts
+++ b/src/Storage/LocalStorage.ts
@@ -24,7 +24,7 @@ import {
 } from '../types';
 import {promisify} from "util";
 import {MetadataConverter} from "../utils/MetadataConverter";
-import {InvalidInput} from "../Exceptions/InvalidInput";
+import {InvalidInput} from "../Exceptions";
 
 function handleError(err: Error & { code: string; path?: string }, fullPath: string): Error {
 	switch (err.code) {
@@ -46,8 +46,8 @@ export class LocalStorage extends Storage {
 	constructor(config: LocalFileSystemConfig) {
 		super();
 		this.$root = resolve(config.root);
-		this.$dataDirectory = config.dataDirectory || join(this.$root, 'data');
-		this.$metaDirectory = config.metadataDirectory || join(this.$root, 'meta');
+		this.$dataDirectory = config.dataDirectory ? resolve(config.dataDirectory) : join(this.$root, 'data');
+		this.$metaDirectory = config.metadataDirectory ? resolve(config.metadataDirectory) : join(this.$root, 'meta');
 	}
 
 	static fromConfig(config: LocalFileSystemConfig): Storage {

--- a/src/Storage/Storage.ts
+++ b/src/Storage/Storage.ts
@@ -18,7 +18,6 @@ import {
 } from '../types';
 
 export interface StorageConstructor<T extends Storage = Storage> {
-	new(...args: any[]): T;
 	fromConfig(config: object): T;
 }
 

--- a/src/Storage/index.ts
+++ b/src/Storage/index.ts
@@ -9,10 +9,12 @@ import { AmazonWebServicesS3Storage } from './AmazonWebServicesS3Storage';
 import { AzureBlockBlobStorage } from "./AzureBlockBlobStorage";
 import { GoogleCloudStorage } from './GoogleCloudStorage';
 import { LocalStorage } from './LocalStorage';
+import { Storage as AbstractStorage } from './Storage';
 
-export default {
+export {
 	AmazonWebServicesS3Storage,
 	AzureBlockBlobStorage,
 	GoogleCloudStorage,
 	LocalStorage,
+	AbstractStorage,
 };

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -17,12 +17,12 @@ export class StorageManager {
 	/**
 	 * Configuration of the storage manager.
 	 */
-	private readonly _config: StorageManagerConfig;
+	private _config: StorageManagerConfig;
 
 	/**
 	 * Created disk instances
 	 */
-	private readonly _diskInstances: Map<string, GenericStorage>;
+	private _diskInstances: Map<string, GenericStorage>;
 
 	/**
 	 * List of available storages
@@ -30,12 +30,16 @@ export class StorageManager {
 	private _storages: Map<string, StorageConstructor> = new Map();
 
 	constructor(config: StorageManagerConfig) {
-		this._config = Object.assign({disks: {}}, config);
-		this._diskInstances = new Map();
+		this.config(config);
 		this.registerStorage('azureBlob', AzureBlockBlobStorage);
 		this.registerStorage('gcs', GoogleCloudStorage);
 		this.registerStorage('local', LocalStorage);
 		this.registerStorage('s3', AmazonWebServicesS3Storage);
+	}
+
+	config(config: StorageManagerConfig) {
+		this._config = Object.assign({disks: {}}, config);
+		this._diskInstances = new Map();
 	}
 
 	addDisk(name: string, config: StorageManagerDiskConfig) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
-export { StorageManager } from './StorageManager';
+import {StorageManager} from './StorageManager';
+
+export {StorageManager};
 export * from './Storage';
 export * from './types';
+export const manager = new StorageManager({disks: {}});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig",
+  "include": ["./**/*"]
+}

--- a/test/unit/azure-bbs-driver.spec.ts
+++ b/test/unit/azure-bbs-driver.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import uuid from 'uuid';
 
-import { AzureBlockBlobStorage } from "../../src/Storage/AzureBlockBlobStorage";
+import { AzureBlockBlobStorage } from '../../src/Storage';
 import { BlobServiceClient } from "@azure/storage-blob";
 import { streamToString } from "../../src/utils/streamToString";
 import { AuthorizationRequired } from "../../src/Exceptions";

--- a/test/unit/gcs-driver.spec.ts
+++ b/test/unit/gcs-driver.spec.ts
@@ -1,6 +1,6 @@
 import uuid from 'uuid/v4';
 
-import { GoogleCloudStorage } from '../../src/Storage/GoogleCloudStorage';
+import { GoogleCloudStorage } from '../../src/Storage';
 import { runGenericStorageSpec } from "../stubs/storage.generic";
 
 const testBucket = process.env.GCS_BUCKET || 'flydrive-test';

--- a/test/unit/local-driver.spec.ts
+++ b/test/unit/local-driver.spec.ts
@@ -6,7 +6,7 @@
  */
 import path from 'path';
 
-import { LocalStorage } from "../../src/Storage/LocalStorage";
+import { LocalStorage } from '../../src/Storage';
 import { runGenericStorageSpec } from "../stubs/storage.generic";
 import { MethodNotSupported } from "../../src/Exceptions";
 

--- a/test/unit/s3-driver.spec.ts
+++ b/test/unit/s3-driver.spec.ts
@@ -6,10 +6,10 @@
  */
 
 import S3 from "aws-sdk/clients/s3";
-import { AmazonWebServicesS3Storage, AWSS3Config } from '../../src/Storage/AmazonWebServicesS3Storage';
+import { AmazonWebServicesS3Storage } from '../../src/Storage/AmazonWebServicesS3Storage';
 import { runGenericStorageSpec } from "../stubs/storage.generic";
 
-const config: AWSS3Config = {
+const config = {
 	key: process.env.S3_KEY || '',
 	secret: process.env.S3_SECRET || '',
 	bucket: process.env.S3_BUCKET || '',
@@ -21,13 +21,13 @@ const driver = new S3({
 	secretAccessKey: config.secret,
 	...config,
 });
-const storage = new AmazonWebServicesS3Storage(driver, config.bucket);
+const storage = AmazonWebServicesS3Storage.fromConfig(config);
 
 describe('Amazon Web Services S3 Storage', () => {
 	describe('.getUrl', () => {
 		test('get public url to a file', () => {
 			const url = storage.getUrl('dummy-file1.txt');
-			expect(url).toStrictEqual(`https://${driver.endpoint.host}/${config.bucket}/dummy-file1.txt`);
+			expect(url).toStrictEqual(`https://${config.bucket}.${driver.endpoint.host}/dummy-file1.txt`);
 		});
 
 		test('get public url to a file when region is not defined', () => {

--- a/test/unit/s3-driver.spec.ts
+++ b/test/unit/s3-driver.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import S3 from "aws-sdk/clients/s3";
-import { AmazonWebServicesS3Storage } from '../../src/Storage/AmazonWebServicesS3Storage';
+import { AmazonWebServicesS3Storage } from '../../src/Storage';
 import { runGenericStorageSpec } from "../stubs/storage.generic";
 
 const config = {

--- a/test/unit/storage-manager.spec.ts
+++ b/test/unit/storage-manager.spec.ts
@@ -7,8 +7,8 @@
 
 import { resolve } from 'path';
 
-import { StorageManager } from '../../src/StorageManager';
-import { LocalStorage } from '../../src/Storage/LocalStorage';
+import { StorageManager } from '../../src';
+import { LocalStorage } from '../../src/Storage';
 import { Storage } from "../../src/Storage/Storage";
 
 describe('Storage Manager', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["es2017", "dom"],
@@ -13,6 +12,6 @@
     "outDir": "build",
     "removeComments": false,
     "strictNullChecks": true,
-    "target": "es2017",
+    "target": "es2017"
   }
 }


### PR DESCRIPTION
Added a default storage manager to main export, as well as a config() method for the StorageManager class in order to reconfigure the default storage manager without reinstantiating. This allows callers to do storage manager setup once at application start and reuse the same instances without needing to require() a separate file where a configured StorageManager has been set up. This is a similar pattern to how popular database and logging libraries export default containers for connections or loggers. Seeing as storage drivers fall under a similar class of reusability throughout an application, use of this pattern seems appropriate in this library.

Note: I submitted this to slynova-org as well, but that repo doesn't seem to be particularly active, and seeing as you've put all this work into actually making some active improvements I figured I'd just try here instead of publishing yet another version of this library.

Additional note: I did some incredibly minor cleanup both for eslint as well as for the actual build (needed to add 'dom' to the lib in tsconfig), don't know if this is something that has changed in the last two months or what.. regardless its just a type checking thing, don't think it actually impacts any of the output.